### PR TITLE
disable extension if tab.url isn't memrise course

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -45,21 +45,28 @@
 </style>
 
 <body>
+  <script src="popup.js"></script>
+
   <div style="width: 150px;">
-    <script src="popup.js"></script>
+
     <h1>Memrise Export</h1>
 
-    <div>
-      <input type="radio" id="words-all" name="words" checked>
-      <label for="words-all">All words</label>
-    </div>
+    <form id="form">
 
-    <div>
-      <input type="radio" id="words-difficult" name="words">
-      <label for="words-difficult" id="difflabel">Difficult words (Memrise Pro only)</label>
-    </div>
-    <input id="export" type="button" value="Export" class="button" style="margin-top: 15px; width: 100%;" />
+      <div>
+        <input type="radio" id="words-all" name="words" checked>
+        <label for="words-all">All words</label>
+      </div>
+
+      <div>
+        <input type="radio" id="words-difficult" name="words">
+        <label for="words-difficult" id="difflabel">Difficult words (Memrise Pro only)</label>
+      </div>
+      <input id="export" type="button" value="Export" class="button" style="margin-top: 15px; width: 100%;" />
+    </form>
+
     <div id="message">Loading (0%)</div>
+
   </div>
 </body>
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -143,7 +143,7 @@ const run = () => {
     if (tsvWords.length > 0) {
       chrome.runtime.sendMessage({
         type: 'download',
-        filename: `${courseSlug || slug}${difficultWords ? '-difficult-words' : ''}.tsv`,
+        filename: `${courseSlug || slug}${difficultWords ? '-difficult-words.tsv' : ''}.tsv`,
         text: tsvWords,
       })
 
@@ -162,29 +162,33 @@ const run = () => {
 
 // run when the export button is clicked
 document.addEventListener('DOMContentLoaded', function () {
-  // if the tab's url is not a Memrise course, disable all the extension features 
+
+  // if the tab's url is not a Memrise course, disable all the extension features
   chrome.tabs.query({
     active: true,
     currentWindow: true
   }, async tabs => {
 
     const tab = tabs[0]
-    const number_slash = tab.url.split("/").length - 1 // 6 when on a course page, 7 when on a level page
-    if (!tab.url.includes('https://app.memrise.com/course/') || number_slash != 6) {
+    const numberSlash = tab.url.split('/').length - 1 // 6 when on a course page, 7 when on a level page
+    if (!tab.url.includes('https://app.memrise.com/course/') || numberSlash !== 6) {
       print('Works only on Memrise course pages:\n app.memrise.com/course/*')
-      const main = document.getElementById("main")
-      main.style.cursor = "not-allowed";
-      var childelements_of_main = main.getElementsByTagName('*')
-      for (i = 0; i < childelements_of_main.length; ++i) {
-        const element = childelements_of_main[i];
-        element.disabled = true;
-        element.style.cursor = "not-allowed";
-        if (element.id == "export") {
-          element.style.backgroundColor = "grey";
+      const main = document.getElementById('main')
+      main.style.cursor = 'not-allowed'
+      const childElementsOfMain = main.getElementsByTagName('*')
+      console.log(childElementsOfMain)
+      Array.from(childElementsOfMain).forEach(function(element) {
+        console.log(element)
+        element.disabled = true
+        element.style.cursor = 'not-allowed'
+        if (element.id === 'export') {
+          element.style.backgroundColor = 'grey'
         }
-      }
+      })
+    }
+    else {
+      document.getElementById('export').addEventListener('click', run)
+    }
 
-    } else {}
-   document.getElementById('export').addEventListener('click', run)
   })
 }, false)

--- a/src/popup.js
+++ b/src/popup.js
@@ -143,7 +143,7 @@ const run = () => {
     if (tsvWords.length > 0) {
       chrome.runtime.sendMessage({
         type: 'download',
-        filename: `${courseSlug || slug}${difficultWords ? '-difficult-words.tsv' : ''}.tsv`,
+        filename: `${courseSlug || slug}${difficultWords ? '-difficult-words' : ''}.tsv`,
         text: tsvWords,
       })
 
@@ -162,5 +162,29 @@ const run = () => {
 
 // run when the export button is clicked
 document.addEventListener('DOMContentLoaded', function () {
-  document.getElementById('export').addEventListener('click', run)
+  // if the tab's url is not a Memrise course, disable all the extension features 
+  chrome.tabs.query({
+    active: true,
+    currentWindow: true
+  }, async tabs => {
+
+    const tab = tabs[0]
+    const number_slash = tab.url.split("/").length - 1 // 6 when on a course page, 7 when on a level page
+    if (!tab.url.includes('https://app.memrise.com/course/') || number_slash != 6) {
+      print('Works only on Memrise course pages:\n app.memrise.com/course/*')
+      const main = document.getElementById("main")
+      main.style.cursor = "not-allowed";
+      var childelements_of_main = main.getElementsByTagName('*')
+      for (i = 0; i < childelements_of_main.length; ++i) {
+        const element = childelements_of_main[i];
+        element.disabled = true;
+        element.style.cursor = "not-allowed";
+        if (element.id == "export") {
+          element.style.backgroundColor = "grey";
+        }
+      }
+
+    } else {}
+   document.getElementById('export').addEventListener('click', run)
+  })
 }, false)

--- a/src/popup.js
+++ b/src/popup.js
@@ -111,12 +111,6 @@ const run = () => {
 
     const tab = tabs[0]
 
-    if (!tab.url.includes('https://app.memrise.com/course/')) {
-      alert('Only works on Memrise course pages: https://app.memrise.com/course/*')
-      window.close()
-      return
-    }
-
     // parse the course id
     const courseIdMatch = tab.url.slice('https://app.memrise.com/course'.length).match(/\d+/)
     const id = courseIdMatch && courseIdMatch[0]
@@ -161,7 +155,7 @@ const run = () => {
 }
 
 // run when the export button is clicked
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', () => {
 
   // if the tab's url is not a Memrise course, disable all the extension features
   chrome.tabs.query({
@@ -170,19 +164,17 @@ document.addEventListener('DOMContentLoaded', function () {
   }, async tabs => {
 
     const tab = tabs[0]
-    const numberSlash = tab.url.split('/').length - 1 // 6 when on a course page, 7 when on a level page
-    if (!tab.url.includes('https://app.memrise.com/course/') || numberSlash !== 6) {
+    const isCoursePage = tab.url.match(/^https:\/\/app.memrise.com\/course\/[^/]+\/[^/]+\/$/)
+    if (!isCoursePage) {
       print('Works only on Memrise course pages:\n app.memrise.com/course/*')
-      const main = document.getElementById('main')
-      main.style.cursor = 'not-allowed'
-      const childElementsOfMain = main.getElementsByTagName('*')
-      console.log(childElementsOfMain)
-      Array.from(childElementsOfMain).forEach(function(element) {
-        console.log(element)
-        element.disabled = true
-        element.style.cursor = 'not-allowed'
-        if (element.id === 'export') {
-          element.style.backgroundColor = 'grey'
+      const form = document.getElementById('form')
+      form.style.cursor = 'not-allowed'
+      const childElementsOfMain = form.getElementsByTagName('*')
+      Array.from(childElementsOfMain).forEach(el => {
+        el.disabled = true
+        el.style.cursor = 'not-allowed'
+        if (el.type === 'button') {
+          el.style.backgroundColor = 'grey'
         }
       })
     }


### PR DESCRIPTION
Here is one way of implementing the warning before hitting Export. 

In fact I couldn't simply use the  `(async function () {})` as I told you last time (I didn't careful tested my implementation) as somehow `run` started by itself once the extension was open even though it was only called by the click event and no click was sent. I don't understand why and I could find an explanation, but anyway, I could work around this by keeping the `chrome.tabs.query` also in `run` even though it's already called in `document.addEventListener('DOMContentLoaded')` and we could have simply pass  `tab` to run. It's a dirty way to solve another mystery of the _mysterious_ `async function`.

I also removed the double .tsv extension for the "difficult-words" file.